### PR TITLE
Reworked page authorization to use locals/hooks

### DIFF
--- a/src/lib/components/tournament-page/TournamentTeams.svelte
+++ b/src/lib/components/tournament-page/TournamentTeams.svelte
@@ -5,7 +5,7 @@
 
 	export let tournament: db.FullyPopulatedTournament;
 	export let editPerms: boolean;
-	export let sessionUserTeam: db.TeamWithMembers | null;
+	export let sessionUserTeam: db.TeamWithMembers | undefined;
 	let { team_size, Teams } = tournament;
 </script>
 

--- a/src/routes/(main)/tournaments/[id]/+page.svelte
+++ b/src/routes/(main)/tournaments/[id]/+page.svelte
@@ -4,13 +4,11 @@
 	import Teams from '$lib/components/tournament-page/TournamentTeams.svelte';
 	import Matches from '$lib/components/tournament-page/TournamentMatches.svelte';
 	import Button from '$lib/components/common/LargeButton.svelte';
+	import type { LayoutServerData } from './$types';
 
-	export let data: {
-		tournament: db.FullyPopulatedTournament;
-		editPerms: boolean;
-		sessionUserTeam: db.TeamWithMembers | null;
-	};
-	let { tournament, editPerms, sessionUserTeam } = data;
+	export let data: LayoutServerData;
+	let { tournament, perms, sessionUserTeam } = data;
+	let editPerms = perms.edit;
 	let { name, acronym, id, color, team_size } = tournament;
 </script>
 

--- a/src/routes/(main)/tournaments/[id]/staff-dashboard/+layout.server.ts
+++ b/src/routes/(main)/tournaments/[id]/staff-dashboard/+layout.server.ts
@@ -2,12 +2,8 @@ import { error } from "@sveltejs/kit";
 import type { LayoutServerLoad } from "./$types";
 import { StatusCodes } from "$lib/StatusCodes";
 
-export const load: LayoutServerLoad = async ({ parent }) => {
-    const { tournament, editPerms, user } = await parent();
-
-    if (!editPerms) {
+export const load: LayoutServerLoad = async ({ locals }) => {
+    if (!locals.perms?.edit) {
         throw error(StatusCodes.UNAUTHORIZED, 'You do not have permission to access this page.');
     }
-
-    return { tournament, user };
 }

--- a/src/routes/(main)/tournaments/[id]/staff-dashboard/matches/+page.svelte
+++ b/src/routes/(main)/tournaments/[id]/staff-dashboard/matches/+page.svelte
@@ -10,7 +10,7 @@
     let { tournamentName, teams, rounds } = data;
     let selectedMatch: db.MatchWithTeams | undefined = undefined;
 
-    function onDrop(updatedTeams: db.TeamWithMembers[]) {
+    function onDrop(updatedTeams: db.TeamWithMembersAndMatches[]) {
         teams = updatedTeams;
     }
 

--- a/src/routes/(main)/tournaments/[id]/teams/[team_id]/+layout.server.ts
+++ b/src/routes/(main)/tournaments/[id]/teams/[team_id]/+layout.server.ts
@@ -2,8 +2,8 @@ import { error } from '@sveltejs/kit';
 import type { LayoutServerLoad } from './$types';
 import { StatusCodes } from '$lib/StatusCodes';
 
-export const load: LayoutServerLoad = async ({ params, parent }) => {
-	const { tournament, user } = await parent();
+export const load: LayoutServerLoad = async ({ params, parent, locals }) => {
+	const { tournament } = await parent();
 
 	// Retrieve team from tournament and params
 	const team = tournament.Teams.find((team) => team.id === parseInt(params.team_id));
@@ -17,8 +17,8 @@ export const load: LayoutServerLoad = async ({ params, parent }) => {
 
 	// Team captains have a member_order of 0
 	const isTeamCaptain = team.Members.some(
-		(member) => member.osuId === user?.id && member.member_order === 0
+		(member) => member.osuId === locals.user?.id && member.member_order === 0
 	);
 
-	return { tournament, user, team, isTeamCaptain };
+	return { team, isTeamCaptain };
 };

--- a/src/routes/(main)/tournaments/[id]/teams/[team_id]/+page.svelte
+++ b/src/routes/(main)/tournaments/[id]/teams/[team_id]/+page.svelte
@@ -4,21 +4,17 @@
 	import InvitePlayer from '$lib/components/tournament-page/team-page/InvitePlayer.svelte';
 	import TournamentPageTemplate from '$lib/components/tournament-page/TournamentPageTemplate.svelte';
 	import MatchList from '$lib/components/common/MatchList.svelte';
-	import type { PageServerData, ActionData, LayoutServerData } from './$types';
+	import type { PageServerData, ActionData, LayoutServerData, LayoutData } from './$types';
 	import EditPageSetting from '$lib/components/tournament-page/edit-page/EditPageSetting.svelte';
 
-	export let data: PageServerData & LayoutServerData;
+	export let data: PageServerData & LayoutServerData & LayoutData;
 	export let form: ActionData;
-	let { tournament, team, isTeamCaptain } = data;
+	let { tournament, team, isTeamCaptain, sessionUserTeam } = data;
+	let { team_size: maxTeamSize } = tournament;
 	let { name, Members, color, InBracketMatches } = team;
 
-	let inTeam: boolean = false;
-	function updateInTeam(memberId: number) {
-		if (memberId == data.user?.id) {
-			inTeam = true;
-		}
-		return '';
-	}
+	// Check if this team is the current user's team
+	let inTeam: boolean = (team.id == sessionUserTeam?.id);
 </script>
 
 <svelte:head>
@@ -32,19 +28,18 @@
 
 	<section class="team_header">
 		<h1>
-			{tournament.team_size == 1 ? 'Player: ' : 'Team: '}
+			{maxTeamSize == 1 ? 'Player: ' : 'Team: '}
 			{team.name}
 		</h1>
 	</section>
 
 	<section class="players">
-		{#if tournament.team_size != 1}
+		{#if maxTeamSize != 1}
 			<h1>Players</h1>
 		{/if}
 		<div class="player_cards">
 			{#each Members as member}
 				<User user={member.User} {color} />
-				{updateInTeam(member.User.id)}
 			{/each}
 		</div>
 		{#if inTeam && !isTeamCaptain}
@@ -62,13 +57,15 @@
 			<h1>Team Settings</h1>
 
 			<form id="team_settings" method="POST" action="?/update_team">
-				<EditPageSetting
-					name="name"
-					label="Team Name"
-					value={name}
-					errors={form?.messages}
-					type="text"
-				/>
+				{#if maxTeamSize != 1}
+					<EditPageSetting
+						name="name"
+						label="Team Name"
+						value={name}
+						errors={form?.messages}
+						type="text"
+					/>
+				{/if}
 				<EditPageSetting
 					name="color"
 					label="Team Color"
@@ -92,11 +89,11 @@
 			{/if}
 		</section>
 
-		{#if tournament.team_size != 1 && tournament.allow_registrations}
+		{#if maxTeamSize != 1 && tournament.allow_registrations}
 			<section class="invites">
 				<h1>Team Invites</h1>
 
-				{#if team.Members.length < tournament.team_size}
+				{#if team.Members.length < maxTeamSize}
 					<InvitePlayer {data} {form} />
 				{:else}
 					<p>Your team is full. You can't invite anymore players.</p>

--- a/src/routes/(main)/tournaments/[id]/teams/new/+page.server.ts
+++ b/src/routes/(main)/tournaments/[id]/teams/new/+page.server.ts
@@ -5,23 +5,22 @@ import vine, { errors } from '@vinejs/vine';
 import { parseFormData } from 'parse-nested-form-data';
 import { StatusCodes } from '$lib/StatusCodes';
 
-export const load: PageServerLoad = async ({ parent }) => {
-	const { tournament, user, editPerms } = await parent();
+export const load: PageServerLoad = async ({ parent, locals }) => {
+	const { user, perms } = locals;
+	const { tournament } = await parent();
+
 	// If user isn't logged in
 	if (!user) {
 		throw error(StatusCodes.UNAUTHORIZED, 'You must log in with osu! to register.');
 	}
 
 	// Check if the user has staff permissions for this tournament
-	if (editPerms) {
+	if (perms.edit) {
 		throw error(StatusCodes.BAD_REQUEST, 'You can\'t sign up for your own tournament.');
 	}
 
 	// Check if this user is already in a team in this tournament
-	const isInTeam = tournament?.Teams?.find((team) =>
-		team.Members.some((member) => member.osuId === user?.id)
-	);
-	if (isInTeam) {
+	if (perms.playing) {
 		throw error(StatusCodes.BAD_REQUEST, 'You are already registered in this tournament.');
 	}
 


### PR DESCRIPTION
Note that this is ONLY for page authorization, so no authentication for actions for now. (I've been looking into whether Sveltekit actions can be invoked externally with custom POST requests, but haven't found anything yet. If I do find something, then authentication for actions would be necessary)

I did some testing to see if the permissions could accidentally carry over between pages where the permissions are supposed to change; there were no problems. Also while doing so I did confirm that `+layout.server.svelte` files do run every time a page is loaded (which includes all parent layouts, from top to bottom, even if `parent()` is not called).